### PR TITLE
Fix connection cleanup on territory deletion

### DIFF
--- a/src/context/MapContext.tsx
+++ b/src/context/MapContext.tsx
@@ -179,7 +179,16 @@ function mapReducer(state: MapState, action: MapAction): MapState {
           territory.connections = territory.connections.filter(id => id !== action.payload);
         }
       });
-      return { ...state, territories: remainingTerritories };
+      return {
+        ...state,
+        territories: remainingTerritories,
+        connections: state.connections.filter(
+          conn => conn.from !== action.payload && conn.to !== action.payload
+        ),
+        freehandConnections: state.freehandConnections.filter(
+          conn => conn.from !== action.payload && conn.to !== action.payload
+        ),
+      };
     
     case 'TOGGLE_VIEW_SETTING':
       return {


### PR DESCRIPTION
## Summary
- ensure deleting a territory also removes related connections and freehand connections

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684558b1aeac832ab97140bf3ce6c100